### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Xinabox
 maintainer= xinabox <support@xinabox.cc>
 sentence=Simple library to interface OC06 Driver
 paragraph=Simple library to interface OC06 Driver
-category=Output
+category=Device Control
 url=https://github.com/xinabox/arduino-OC05
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Output' in library arduino-0C06 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format