### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Instance			   		(KEYWORD1)
 #######################################
 
-OC06    KEYWORD1
+OC06	KEYWORD1
 
 #######################################
 # Methods and Functions		(KEYWORD2)
 #######################################
 
-begin   KEYWORD2
-step    KEYWORD2
-setDirection   KEYWORD2
-enable  KEYWORD2
-disable KEYWORD2
-move    KEYWORD2
+begin	KEYWORD2
+step	KEYWORD2
+setDirection	KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
+move	KEYWORD2
 
 #######################################
 # Constants 		   		(LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords